### PR TITLE
Update Carrierwave to use 1.0.0 stable

### DIFF
--- a/archangel.gemspec
+++ b/archangel.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "acts_as_tree", "~> 2.6.0"
   s.add_dependency "bootstrap-sass", "~> 3.3.7"
   s.add_dependency "bootstrap3-datetimepicker-rails", "~> 4.17.43"
-  s.add_dependency "carrierwave", ">= 1.0.0.beta", "< 2.0"
+  s.add_dependency "carrierwave", "~> 1.0.0"
   s.add_dependency "date_validator", "~> 0.9.0"
   s.add_dependency "devise", "~> 4.2.0"
   s.add_dependency "devise_invitable", "~> 1.7.0"


### PR DESCRIPTION
# Summary

Updating Carrierwave to `~> 1.0.0`. I was using an RC because Archangel uses Rspec 3 and I was waiting for Carrierwave to update.