### PR TITLE
Abort Generator

### DIFF
--- a/lib/generators/archangel/dummy/dummy_generator.rb
+++ b/lib/generators/archangel/dummy/dummy_generator.rb
@@ -22,6 +22,12 @@ module Archangel
         paths.flatten
       end
 
+      def prevent_application_dummy
+        return unless Rails.respond_to?(:root) && !Rails.root.nil?
+
+        abort "Dummy generator cannot be run outside Archangel extension."
+      end
+
       def clean_up
         remove_directory_if_exists(dummy_path)
       end

--- a/lib/generators/archangel/install/install_generator.rb
+++ b/lib/generators/archangel/install/install_generator.rb
@@ -25,6 +25,12 @@ module Archangel
       class_option :route_path, type: :string, default: "", desc: "Root path"
       class_option :seed, type: :boolean, default: false, desc: "Seed database"
 
+      def prevent_nested_install
+        return unless Rails.respond_to?(:root) && Rails.root.nil?
+
+        abort "Install generator cannot be run inside Archangel extension."
+      end
+
       def create_assets
         say_quietly "Copying Archangel vendor assets..."
 


### PR DESCRIPTION
# Summary

Prevent running Archangel generators from running where they shouldn't be run.

This fixed issue #3 

## What's new

- Prevent install generator (`bundle exec rails g archangel:install`) from running inside Archangel extension
- Prevent dummy generator (`bundle exec rails g archangel:dummy`) from running outside Archangel extension