### PR TITLE
Bump simple_form and scss_lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development do
   gem "brakeman", "~> 3.4.1"
   gem "reek", "~> 4.5.3"
   gem "rubocop", "~> 0.46.0"
-  gem "scss_lint", "~> 0.51.0"
+  gem "scss_lint", "~> 0.52.0"
   gem "yard", "~> 0.9.5"
 end
 

--- a/archangel.gemspec
+++ b/archangel.gemspec
@@ -42,6 +42,6 @@ Gem::Specification.new do |s|
   s.add_dependency "ransack", "~> 1.8.2"
   s.add_dependency "responders", "~> 2.3.0"
   s.add_dependency "select2-rails", "~> 4.0.3"
-  s.add_dependency "simple_form", "~> 3.3.1"
+  s.add_dependency "simple_form", "~> 3.4.0"
   s.add_dependency "validates", "~> 1.0.0"
 end


### PR DESCRIPTION
# Summary

Update gem versions to satisfy [Gemnasium](https://gemnasium.com/github.com/archangel/archangel)

## What's new

- Update `scss_lint` from 0.51.0 to 0.52.0
- Update `simple_form` from 3.3.1 to 3.4.0