### PR TITLE
frozen_string_literal

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Style/Documentation:
 Style/DotPosition:
   EnforcedStyle: leading
 
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/setup"
 rescue LoadError

--- a/app/controllers/archangel/admin/assets_controller.rb
+++ b/app/controllers/archangel/admin/assets_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin assets controller

--- a/app/controllers/archangel/admin/categories_controller.rb
+++ b/app/controllers/archangel/admin/categories_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin categories controller

--- a/app/controllers/archangel/admin/dashboards_controller.rb
+++ b/app/controllers/archangel/admin/dashboards_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin dashboard controller

--- a/app/controllers/archangel/admin/pages_controller.rb
+++ b/app/controllers/archangel/admin/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin pages controller

--- a/app/controllers/archangel/admin/posts_controller.rb
+++ b/app/controllers/archangel/admin/posts_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin posts controller

--- a/app/controllers/archangel/admin/profiles_controller.rb
+++ b/app/controllers/archangel/admin/profiles_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin profile controller

--- a/app/controllers/archangel/admin/sites_controller.rb
+++ b/app/controllers/archangel/admin/sites_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin site controller

--- a/app/controllers/archangel/admin/tags_controller.rb
+++ b/app/controllers/archangel/admin/tags_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin tags controller

--- a/app/controllers/archangel/admin/users_controller.rb
+++ b/app/controllers/archangel/admin/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin users controller

--- a/app/controllers/archangel/admin_controller.rb
+++ b/app/controllers/archangel/admin_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Admin controller
   #

--- a/app/controllers/archangel/application_controller.rb
+++ b/app/controllers/archangel/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "archangel/application_responder"
 
 module Archangel

--- a/app/controllers/archangel/auth_controller.rb
+++ b/app/controllers/archangel/auth_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Auth controller
   #

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Frontend
     # Frontend pages controller

--- a/app/controllers/archangel/frontend/posts_controller.rb
+++ b/app/controllers/archangel/frontend/posts_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Frontend
     # Frontend posts controller

--- a/app/controllers/archangel/frontend_controller.rb
+++ b/app/controllers/archangel/frontend_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Frontend controller
   #

--- a/app/controllers/concerns/archangel/actionable_concern.rb
+++ b/app/controllers/concerns/archangel/actionable_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module ActionableConcern
     extend ActiveSupport::Concern

--- a/app/controllers/concerns/archangel/authenticatable_concern.rb
+++ b/app/controllers/concerns/archangel/authenticatable_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module AuthenticatableConcern
     extend ActiveSupport::Concern

--- a/app/controllers/concerns/archangel/authorizable_concern.rb
+++ b/app/controllers/concerns/archangel/authorizable_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module AuthorizableConcern
     extend ActiveSupport::Concern

--- a/app/controllers/concerns/archangel/skip_authorizable_concern.rb
+++ b/app/controllers/concerns/archangel/skip_authorizable_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module SkipAuthorizableConcern
     extend ActiveSupport::Concern

--- a/app/helpers/archangel/admin/assets_helper.rb
+++ b/app/helpers/archangel/admin/assets_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin assets helpers

--- a/app/helpers/archangel/admin/categories_helper.rb
+++ b/app/helpers/archangel/admin/categories_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin categories helpers

--- a/app/helpers/archangel/admin/dashboards_helper.rb
+++ b/app/helpers/archangel/admin/dashboards_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin dashboard helpers

--- a/app/helpers/archangel/admin/pages_helper.rb
+++ b/app/helpers/archangel/admin/pages_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin pages helpers

--- a/app/helpers/archangel/admin/posts_helper.rb
+++ b/app/helpers/archangel/admin/posts_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin posts helpers

--- a/app/helpers/archangel/admin/profiles_helper.rb
+++ b/app/helpers/archangel/admin/profiles_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin profile helpers

--- a/app/helpers/archangel/admin/sites_helper.rb
+++ b/app/helpers/archangel/admin/sites_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin site helpers

--- a/app/helpers/archangel/admin/tags_helper.rb
+++ b/app/helpers/archangel/admin/tags_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin tags helpers

--- a/app/helpers/archangel/admin/users_helper.rb
+++ b/app/helpers/archangel/admin/users_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Admin
     # Admin users helpers

--- a/app/helpers/archangel/admin_helper.rb
+++ b/app/helpers/archangel/admin_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Admin helpers
   #

--- a/app/helpers/archangel/application_helper.rb
+++ b/app/helpers/archangel/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Application helpers
   #

--- a/app/helpers/archangel/auth_helper.rb
+++ b/app/helpers/archangel/auth_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Auth helpers
   #

--- a/app/helpers/archangel/flash_helper.rb
+++ b/app/helpers/archangel/flash_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Flash message helpers
   #

--- a/app/helpers/archangel/frontend/pages_helper.rb
+++ b/app/helpers/archangel/frontend/pages_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Frontend
     # Frontend pages helpers

--- a/app/helpers/archangel/frontend/posts_helper.rb
+++ b/app/helpers/archangel/frontend/posts_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Frontend
     # Frontend posts helpers

--- a/app/helpers/archangel/frontend_helper.rb
+++ b/app/helpers/archangel/frontend_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Frontend helpers
   #

--- a/app/inputs/categories_input.rb
+++ b/app/inputs/categories_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CategoriesInput < SimpleForm::Inputs::CollectionSelectInput
   def input_options
     super.tap do |options|

--- a/app/inputs/date_picker_input.rb
+++ b/app/inputs/date_picker_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DatePickerInput < SimpleForm::Inputs::Base
   def input(_wrapper_options)
     template.content_tag(:div, class: "input-group") do

--- a/app/inputs/date_time_picker_input.rb
+++ b/app/inputs/date_time_picker_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DateTimePickerInput < DatePickerInput
   def input_html_options
     super.merge(class: "form-control datetimepicker")

--- a/app/inputs/language_input.rb
+++ b/app/inputs/language_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LanguageInput < SimpleForm::Inputs::CollectionSelectInput
   def multiple?
     false

--- a/app/inputs/meta_keywords_input.rb
+++ b/app/inputs/meta_keywords_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MetaKeywordsInput < SimpleForm::Inputs::CollectionSelectInput
   def input_options
     super.tap do |options|

--- a/app/inputs/parent_page_input.rb
+++ b/app/inputs/parent_page_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ParentPageInput < SimpleForm::Inputs::CollectionSelectInput
   def multiple?
     false

--- a/app/inputs/role_input.rb
+++ b/app/inputs/role_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RoleInput < SimpleForm::Inputs::CollectionSelectInput
   def multiple?
     false

--- a/app/inputs/tags_input.rb
+++ b/app/inputs/tags_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TagsInput < SimpleForm::Inputs::CollectionSelectInput
   def input_options
     super.tap do |options|

--- a/app/inputs/time_picker_input.rb
+++ b/app/inputs/time_picker_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TimePickerInput < SimpleForm::Inputs::Base
   def input(_wrapper_options)
     template.content_tag(:div, class: "input-group") do

--- a/app/inputs/wysiwyg_input.rb
+++ b/app/inputs/wysiwyg_input.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class WysiwygInput < SimpleForm::Inputs::TextInput
 end

--- a/app/jobs/archangel/application_job.rb
+++ b/app/jobs/archangel/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class ApplicationJob < ActiveJob::Base
   end

--- a/app/mailers/archangel/application_mailer.rb
+++ b/app/mailers/archangel/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class ApplicationMailer < ActionMailer::Base
     default from: "noreply@example.com"

--- a/app/models/archangel/application_record.rb
+++ b/app/models/archangel/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # ApplicationRecord
   #

--- a/app/models/archangel/asset.rb
+++ b/app/models/archangel/asset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Asset model
   #

--- a/app/models/archangel/categorization.rb
+++ b/app/models/archangel/categorization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Categorization model
   #

--- a/app/models/archangel/category.rb
+++ b/app/models/archangel/category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Category model
   #

--- a/app/models/archangel/page.rb
+++ b/app/models/archangel/page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Page model
   #

--- a/app/models/archangel/post.rb
+++ b/app/models/archangel/post.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Post model
   #

--- a/app/models/archangel/site.rb
+++ b/app/models/archangel/site.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Site model
   #

--- a/app/models/archangel/tag.rb
+++ b/app/models/archangel/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Tag model
   #

--- a/app/models/archangel/tagging.rb
+++ b/app/models/archangel/tagging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Tagging model
   #

--- a/app/models/archangel/user.rb
+++ b/app/models/archangel/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # User model
   #

--- a/app/policies/archangel/application_policy.rb
+++ b/app/policies/archangel/application_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Application authorization policies
   #

--- a/app/policies/archangel/asset_policy.rb
+++ b/app/policies/archangel/asset_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Assets authorization policies
   #

--- a/app/policies/archangel/category_policy.rb
+++ b/app/policies/archangel/category_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Cateogries authorization policies
   #

--- a/app/policies/archangel/page_policy.rb
+++ b/app/policies/archangel/page_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Pages authorization policies
   #

--- a/app/policies/archangel/post_policy.rb
+++ b/app/policies/archangel/post_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Posts authorization policies
   #

--- a/app/policies/archangel/site_policy.rb
+++ b/app/policies/archangel/site_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Site authorization policies
   #

--- a/app/policies/archangel/tag_policy.rb
+++ b/app/policies/archangel/tag_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Tags authorization policies
   #

--- a/app/policies/archangel/user_policy.rb
+++ b/app/policies/archangel/user_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Users authorization policies
   #

--- a/app/uploaders/archangel/asset_uploader.rb
+++ b/app/uploaders/archangel/asset_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class AssetUploader < BaseUploader
     def extension_whitelist

--- a/app/uploaders/archangel/avatar_uploader.rb
+++ b/app/uploaders/archangel/avatar_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class AvatarUploader < BaseUploader
     def default_path

--- a/app/uploaders/archangel/base_uploader.rb
+++ b/app/uploaders/archangel/base_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class BaseUploader < CarrierWave::Uploader::Base
     include CarrierWave::MiniMagick

--- a/app/uploaders/archangel/feature_uploader.rb
+++ b/app/uploaders/archangel/feature_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class FeatureUploader < BaseUploader
     def default_path

--- a/app/uploaders/archangel/logo_uploader.rb
+++ b/app/uploaders/archangel/logo_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class LogoUploader < BaseUploader
     def default_path

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.config.assets.precompile += [
   "*.gif", "*.jpeg", "*.jpg", "*.png",
   "*.eot", "*.svg", "*.ttf", "*.woff", "*.woff2",

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CarrierWave.configure do |config|
   # Local file storage
   config.permissions = 0o666

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|

--- a/config/initializers/kaminari.rb
+++ b/config/initializers/kaminari.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Kaminari.configure do |config|
   config.default_per_page = 24
   config.max_per_page = 480

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   config.error_notification_class = "alert alert-danger"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Archangel::Engine.routes.draw do
   # Pagination
   concern :paginatable do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # ruby encoding: utf-8
 
 require "highline/import"

--- a/lib/archangel.rb
+++ b/lib/archangel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "acts_as_list"
 require "acts_as_tree"
 require "bootstrap-sass"

--- a/lib/archangel/application_responder.rb
+++ b/lib/archangel/application_responder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class ApplicationResponder < ActionController::Responder
     include Responders::FlashResponder

--- a/lib/archangel/command/extension.rb
+++ b/lib/archangel/command/extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module Command
     class Extension < Thor::Group

--- a/lib/archangel/configuration.rb
+++ b/lib/archangel/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Application configurations
   #

--- a/lib/archangel/engine.rb
+++ b/lib/archangel/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   class Engine < ::Rails::Engine
     isolate_namespace Archangel

--- a/lib/archangel/i18n.rb
+++ b/lib/archangel/i18n.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "i18n"
 require "active_support/core_ext/array/extract_options"
 

--- a/lib/archangel/languages.rb
+++ b/lib/archangel/languages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   LANGUAGES = %w(en).freeze
   LANGUAGE_DEFAULT = LANGUAGES.first

--- a/lib/archangel/roles.rb
+++ b/lib/archangel/roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   ROLES = %w(admin editor).freeze
   ROLE_DEFAULT = ROLES.last

--- a/lib/archangel/settings.rb
+++ b/lib/archangel/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   # Application setting
   #

--- a/lib/archangel/testing_support/factories/archangel_assets.rb
+++ b/lib/archangel/testing_support/factories/archangel_assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :asset, class: Archangel::Asset do
     association :assetable, factory: :page

--- a/lib/archangel/testing_support/factories/archangel_categories.rb
+++ b/lib/archangel/testing_support/factories/archangel_categories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :category, class: Archangel::Category do
     sequence(:name) { |n| "Category #{n}" }

--- a/lib/archangel/testing_support/factories/archangel_categorizations.rb
+++ b/lib/archangel/testing_support/factories/archangel_categorizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :categorization, class: Archangel::Categorization do
     category

--- a/lib/archangel/testing_support/factories/archangel_pages.rb
+++ b/lib/archangel/testing_support/factories/archangel_pages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :page, class: Archangel::Page do
     sequence(:title) { |n| "Page #{n} Title" }

--- a/lib/archangel/testing_support/factories/archangel_posts.rb
+++ b/lib/archangel/testing_support/factories/archangel_posts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :post, class: Archangel::Post do
     author

--- a/lib/archangel/testing_support/factories/archangel_sites.rb
+++ b/lib/archangel/testing_support/factories/archangel_sites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :site, class: Archangel::Site do
     name "Archangel"

--- a/lib/archangel/testing_support/factories/archangel_taggings.rb
+++ b/lib/archangel/testing_support/factories/archangel_taggings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :tagging, class: Archangel::Tagging do
     tag

--- a/lib/archangel/testing_support/factories/archangel_tags.rb
+++ b/lib/archangel/testing_support/factories/archangel_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :tag, class: Archangel::Tag do
     sequence(:name) { |n| "Tag #{n}" }

--- a/lib/archangel/testing_support/factories/archangel_users.rb
+++ b/lib/archangel/testing_support/factories/archangel_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
   factory :user, aliases: [:author, :uploader], class: Archangel::User do
     sequence(:name) { |n| "User #{n}" }

--- a/lib/archangel/testing_support/helpers/authorization_helpers.rb
+++ b/lib/archangel/testing_support/helpers/authorization_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module TestingSupport
     # Authorization helper test support

--- a/lib/archangel/testing_support/helpers/capybara_helpers.rb
+++ b/lib/archangel/testing_support/helpers/capybara_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module TestingSupport
     # Capybara helper test support

--- a/lib/archangel/testing_support/helpers/controller_helpers.rb
+++ b/lib/archangel/testing_support/helpers/controller_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module TestingSupport
     module ControllerHelpers

--- a/lib/archangel/testing_support/helpers/form_helpers.rb
+++ b/lib/archangel/testing_support/helpers/form_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module TestingSupport
     # Form helper test support

--- a/lib/archangel/testing_support/helpers/time_helpers.rb
+++ b/lib/archangel/testing_support/helpers/time_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   # http://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html
   config.include ActiveSupport::Testing::TimeHelpers

--- a/lib/archangel/testing_support/helpers/url_helpers.rb
+++ b/lib/archangel/testing_support/helpers/url_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module TestingSupport
     # URL helper test support

--- a/lib/archangel/testing_support/matchers/match_stdout.rb
+++ b/lib/archangel/testing_support/matchers/match_stdout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :match_stdout do |check|
   @capture = nil
 

--- a/lib/archangel/testing_support/matchers/pundit.rb
+++ b/lib/archangel/testing_support/matchers/pundit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :permit do |action|
   match do |policy|
     policy.public_send("#{action}?")

--- a/lib/archangel/testing_support/rake/dummy_rake.rb
+++ b/lib/archangel/testing_support/rake/dummy_rake.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 unless defined?(Archangel::Generators::InstallGenerator)
   require "generators/archangel/install/install_generator"
 end

--- a/lib/archangel/testing_support/shared_contexts/rake.rb
+++ b/lib/archangel/testing_support/shared_contexts/rake.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake"
 
 RSpec.shared_context "rake" do

--- a/lib/archangel/testing_support/support.rb
+++ b/lib/archangel/testing_support/support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Support files
 %w(support helpers matchers shared_contexts).each do |type|
   Dir["#{File.dirname(__FILE__)}/#{type}/**/*.rb"].each do |f|

--- a/lib/archangel/testing_support/support/capybara.rb
+++ b/lib/archangel/testing_support/support/capybara.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "capybara/rails"
 require "capybara/rspec"
 

--- a/lib/archangel/testing_support/support/carrierwave.rb
+++ b/lib/archangel/testing_support/support/carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "carrierwave/test/matchers"
 
 RSpec.configure do |config|

--- a/lib/archangel/testing_support/support/controller.rb
+++ b/lib/archangel/testing_support/support/controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails-controller-testing"
 
 RSpec.configure do |config|

--- a/lib/archangel/testing_support/support/database_cleaner.rb
+++ b/lib/archangel/testing_support/support/database_cleaner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "database_cleaner"
 
 RSpec.configure do |config|

--- a/lib/archangel/testing_support/support/devise.rb
+++ b/lib/archangel/testing_support/support/devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "devise"
 
 RSpec.configure do |config|

--- a/lib/archangel/testing_support/support/factory_girl.rb
+++ b/lib/archangel/testing_support/support/factory_girl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "factory_girl_rails"
 
 RSpec.configure do |config|

--- a/lib/archangel/testing_support/support/inputs.rb
+++ b/lib/archangel/testing_support/support/inputs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   module TestingSupport
     module InputExampleGroup

--- a/lib/archangel/testing_support/support/shoulda.rb
+++ b/lib/archangel/testing_support/support/shoulda.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shoulda-matchers"
 require "shoulda-callback-matchers"
 

--- a/lib/archangel/testing_support/support/tasks.rb
+++ b/lib/archangel/testing_support/support/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake"
 
 RSpec.configure do |config|

--- a/lib/archangel/version.rb
+++ b/lib/archangel/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Archangel
   VERSION = "0.0.1".freeze
 end

--- a/lib/generators/archangel/dummy/dummy_generator.rb
+++ b/lib/generators/archangel/dummy/dummy_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/generators/rails/app/app_generator"
 require "active_support/core_ext/hash"
 

--- a/lib/generators/archangel/install/install_generator.rb
+++ b/lib/generators/archangel/install/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/generators"
 require "highline/import"
 

--- a/lib/generators/archangel/install/templates/config/initializers/archangel.rb
+++ b/lib/generators/archangel/install/templates/config/initializers/archangel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Archangel.configure do |config|
   # Admin path.
   # Default is "admin"

--- a/lib/generators/archangel/install/templates/config/initializers/carrierwave.rb
+++ b/lib/generators/archangel/install/templates/config/initializers/carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CarrierWave.configure do |config|
   # Local file storage
   config.storage = :file

--- a/lib/generators/archangel/install/templates/config/initializers/devise.rb.tt
+++ b/lib/generators/archangel/install/templates/config/initializers/devise.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate random
   # tokens. Changing this key will render invalid all existing confirmation,

--- a/spec/command/extension_spec.rb
+++ b/spec/command/extension_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require "archangel/command/extension"
 

--- a/spec/controllers/archangel/admin/assets_controller_spec.rb
+++ b/spec/controllers/archangel/admin/assets_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin/categories_controller_spec.rb
+++ b/spec/controllers/archangel/admin/categories_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin/dashboards_controller_spec.rb
+++ b/spec/controllers/archangel/admin/dashboards_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin/pages_controller_spec.rb
+++ b/spec/controllers/archangel/admin/pages_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin/posts_controller_spec.rb
+++ b/spec/controllers/archangel/admin/posts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin/profiles_controller_spec.rb
+++ b/spec/controllers/archangel/admin/profiles_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin/sites_controller_spec.rb
+++ b/spec/controllers/archangel/admin/sites_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin/tags_controller_spec.rb
+++ b/spec/controllers/archangel/admin/tags_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin/users_controller_spec.rb
+++ b/spec/controllers/archangel/admin/users_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/admin_controller.rb
+++ b/spec/controllers/archangel/admin_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/application_controller_spec.rb
+++ b/spec/controllers/archangel/application_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/auth_controller.rb
+++ b/spec/controllers/archangel/auth_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/frontend/pages_controller_spec.rb
+++ b/spec/controllers/archangel/frontend/pages_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/frontend/posts_controller_spec.rb
+++ b/spec/controllers/archangel/frontend/posts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/controllers/archangel/frontend_controller.rb
+++ b/spec/controllers/archangel/frontend_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/features/account_login_spec.rb
+++ b/spec/features/account_login_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.feature "Account login page", type: :feature do

--- a/spec/features/admin/page_slugs_spec.rb
+++ b/spec/features/admin/page_slugs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.feature "Pages", type: :feature do

--- a/spec/features/admin/user_link_spec.rb
+++ b/spec/features/admin/user_link_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.feature "User links", type: :feature do

--- a/spec/features/home_page_redirect_spec.rb
+++ b/spec/features/home_page_redirect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.feature "Home page", type: :feature do

--- a/spec/helpers/archangel/admin/assets_helper_spec.rb
+++ b/spec/helpers/archangel/admin/assets_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin/categories_helper_spec.rb
+++ b/spec/helpers/archangel/admin/categories_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin/dashboards_helper_spec.rb
+++ b/spec/helpers/archangel/admin/dashboards_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin/pages_helper_spec.rb
+++ b/spec/helpers/archangel/admin/pages_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin/posts_helper_spec.rb
+++ b/spec/helpers/archangel/admin/posts_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin/profiles_helper_spec.rb
+++ b/spec/helpers/archangel/admin/profiles_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin/sites_helper_spec.rb
+++ b/spec/helpers/archangel/admin/sites_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin/tags_helper_spec.rb
+++ b/spec/helpers/archangel/admin/tags_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin/users_helper_spec.rb
+++ b/spec/helpers/archangel/admin/users_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/admin_helper_spec.rb
+++ b/spec/helpers/archangel/admin_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/application_helper_spec.rb
+++ b/spec/helpers/archangel/application_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/auth_helper_spec.rb
+++ b/spec/helpers/archangel/auth_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/flash_helper_spec.rb
+++ b/spec/helpers/archangel/flash_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/frontend/pages_helper_spec.rb
+++ b/spec/helpers/archangel/frontend/pages_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/frontend/posts_helper_spec.rb
+++ b/spec/helpers/archangel/frontend/posts_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/helpers/archangel/frontend_helper_spec.rb
+++ b/spec/helpers/archangel/frontend_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/inputs/date_picker_input_spec.rb
+++ b/spec/inputs/date_picker_input_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Date picker custom input for simple_form", type: :input do

--- a/spec/inputs/date_time_picker_input_spec.rb
+++ b/spec/inputs/date_time_picker_input_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Date time picker custom input for simple_form", type: :input do

--- a/spec/inputs/language_input_spec.rb
+++ b/spec/inputs/language_input_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Language custom input for simple_form", type: :input do

--- a/spec/inputs/parent_page_input_spec.rb
+++ b/spec/inputs/parent_page_input_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Parent page custom input for simple_form", type: :input do

--- a/spec/inputs/role_input_spec.rb
+++ b/spec/inputs/role_input_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Role custom input for simple_form", type: :input do

--- a/spec/inputs/time_picker_input_spec.rb
+++ b/spec/inputs/time_picker_input_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Time picker custom input for simple_form", type: :input do

--- a/spec/jobs/archangel/application_job_spec.rb
+++ b/spec/jobs/archangel/application_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/lib/archangel/configuration_spec.rb
+++ b/spec/lib/archangel/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/lib/archangel/settings_spec.rb
+++ b/spec/lib/archangel/settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/lib/tasks/archangel_tasks_spec.rb
+++ b/spec/lib/tasks/archangel_tasks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Archangel Rake task", type: :rake do

--- a/spec/mailers/archangel/application_mailer_spec.rb
+++ b/spec/mailers/archangel/application_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/asset_spec.rb
+++ b/spec/models/archangel/asset_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/categorization_spec.rb
+++ b/spec/models/archangel/categorization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/category_spec.rb
+++ b/spec/models/archangel/category_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/page_spec.rb
+++ b/spec/models/archangel/page_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/post_spec.rb
+++ b/spec/models/archangel/post_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/site_spec.rb
+++ b/spec/models/archangel/site_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/tag_spec.rb
+++ b/spec/models/archangel/tag_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/tagging_spec.rb
+++ b/spec/models/archangel/tagging_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/models/archangel/user_spec.rb
+++ b/spec/models/archangel/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/policies/archangel/application_policy_spec.rb
+++ b/spec/policies/archangel/application_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/policies/archangel/asset_policy_spec.rb
+++ b/spec/policies/archangel/asset_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/policies/archangel/category_policy_spec.rb
+++ b/spec/policies/archangel/category_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/policies/archangel/page_policy_spec.rb
+++ b/spec/policies/archangel/page_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/policies/archangel/post_policy_spec.rb
+++ b/spec/policies/archangel/post_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/policies/archangel/site_policy_spec.rb
+++ b/spec/policies/archangel/site_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/policies/archangel/tag_policy_spec.rb
+++ b/spec/policies/archangel/tag_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/policies/archangel/user_policy_spec.rb
+++ b/spec/policies/archangel/user_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "simplecov"
 
 SimpleCov.start :rails do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/coveralls.rb
+++ b/spec/support/coveralls.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coveralls"
 
 Coveralls.wear! if ENV["CI"]

--- a/spec/uploaders/archangel/asset_uploader_spec.rb
+++ b/spec/uploaders/archangel/asset_uploader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/uploaders/archangel/avatar_uploader_spec.rb
+++ b/spec/uploaders/archangel/avatar_uploader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/uploaders/archangel/base_uploader_spec.rb
+++ b/spec/uploaders/archangel/base_uploader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/uploaders/archangel/feature_uploader_spec.rb
+++ b/spec/uploaders/archangel/feature_uploader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel

--- a/spec/uploaders/archangel/logo_uploader_spec.rb
+++ b/spec/uploaders/archangel/logo_uploader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Archangel


### PR DESCRIPTION
This is a maintenance PR. This change adds `# frozen_string_literal: true` to the top of every Ruby file. 

Rubocop added the [Style/FrozenStringLiteralComment](https://github.com/bbatsov/rubocop/blob/master/config/default.yml#L587) cop that enforces the presence of the `# frozen_string_literal: true` at the top of every file when running in Ruby 2.3.

Hound recently configured Rubocop to run in Ruby 2.3 by default. Hound will now be commenting on any Ruby file that doesn't have the pragma, with: `Missing frozen string literal comment.` This is intended to prepare code bases for Ruby 3.0, where strings will be frozen by default. 

This change enforces that at the top of every Ruby file. I'm trying to get a jump start to prepare for the future.